### PR TITLE
fix: order inside file permissions diagram

### DIFF
--- a/Day_16/notes_and_exercises.md
+++ b/Day_16/notes_and_exercises.md
@@ -455,15 +455,15 @@ System hardening is the process of reducing an operating system or application's
 ```
 -rwxrw-r--  1 user group 1234 Oct 16 10:00 filename
  ↓↓↓↓↓↓↓↓↓
- ||||||||└─ Other permissions (read)
+ ||||||||└─ Other permissions (execute) - MISSING
  |||||||└── Other permissions (write) - MISSING
- ||||||└─── Other permissions (execute) - MISSING
- |||||└──── Group permissions (read)
+ ||||||└─── Other permissions (read)
+ |||||└──── Group permissions (execute) - MISSING
  ||||└───── Group permissions (write)
- |||└────── Group permissions (execute) - MISSING
- ||└─────── Owner permissions (read)
+ |||└────── Group permissions (read)
+ ||└─────── Owner permissions (execute)
  |└──────── Owner permissions (write)
- └───────── Owner permissions (execute)
+ └───────── Owner permissions (read)
 ```
 
 **Permission Values:**


### PR DESCRIPTION
Inside the diagram of Day 16 the order of permissions was reversed.

Since the arrows resolve from left-bottom to right-top, the first permission (user read) starts at the bottom. 
Before the fix, user execute was at the bottom.